### PR TITLE
Various fixes

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -19,7 +19,7 @@
   </head>
   <body data-decorator="load-ga display-rp-name">
     <div class="banner">
-      <p>Yay, we are piloting the new login experience. Things might break from time to time. <a href="https://discourse.mozilla.org/t/piloting-the-new-lock/23199" class="banner__button">Read more</a></p>
+      <p>We have launched and are actively testing the new login experience. Please report any issues. <a href="https://discourse.mozilla.org/t/piloting-the-new-lock/23199" class="banner__button">More info</a></p>
     </div>
     <div class="card">
       <a href="https://mozilla.org" class="logo"><img alt="Mozilla" src="../images/mozilla.svg" inline /></a>

--- a/src/js/decorators.js
+++ b/src/js/decorators.js
@@ -5,7 +5,6 @@
 var decorators = {
   'init-auth': require( 'decorators/init-auth' ),
   'continue-with-keyboard': require( 'decorators/continue-with-keyboard' ),
-  'auto-login': require( 'decorators/auto-login' ),
   'load-ga': require( 'decorators/load-ga' ),
   'handle-submit': require( 'decorators/handle-submit' ),
   'display-rp-name': require( 'decorators/display-rp-name' ),

--- a/src/js/decorators/auto-login.js
+++ b/src/js/decorators/auto-login.js
@@ -1,8 +1,0 @@
-module.exports = function autoLogin() {
-  /* Ugly hack to auto log you in. Only works with LDAP in this case */
-  var w = window.location.toString();
-
-  if ( w.indexOf( 'tried_silent_auth=true' ) === -1 ) {
-    window.location = w.replace( '/login?', '/authorize?' ).replace( '?client=', '?client_id=' ) + '&sso=true&connection=Mozilla-LDAP-Dev&tried_silent_auth=true';
-  }
-};

--- a/src/js/handlers/authorise-ldap.js
+++ b/src/js/handlers/authorise-ldap.js
@@ -1,13 +1,14 @@
 var ui = require( 'helpers/ui' );
 var fireGAEvent = require( 'helpers/fireGAEvent' );
 var storeLastUsedConnection = require( 'helpers/storeLastUsedConnection' );
+var isDev = require( 'helpers/isDev' );
 
 module.exports = function authorise( element, secondTry ) {
   var form = element.tagName === 'FORM' ? element : element.form;
   var emailField = document.getElementById( 'field-email' );
   var passwordField = secondTry ? document.getElementById( 'field-password-try-2' ) : document.getElementById( 'field-password' );
   var errorText = document.getElementById( 'error-message-ldap' );
-  var connection = 'Mozilla-LDAP-Dev';
+  var connection = isDev ? 'Mozilla-LDAP-Dev' : 'Mozilla-LDAP';
 
   if ( element.id === 'authorise-ldap-credentials-try-2' ) {
     passwordField = document.getElementById( 'field-password-try-2' );

--- a/src/js/handlers/enter.js
+++ b/src/js/handlers/enter.js
@@ -1,11 +1,12 @@
 var ui = require( 'helpers/ui' );
 var fireGAEvent = require( 'helpers/fireGAEvent' );
+var isDev = require( 'helpers/isDev' );
 
 module.exports = function enter( element ) {
   var emailField = document.getElementById( 'field-email' );
   var passwordField = document.getElementById( 'field-password' );
   var isDefinitelyLDAP = /mozilla.com|getpocket.com$/.test( emailField.value );
-  var ENDPOINT = 'https://person-api.sso.allizom.org/v1/connection/';
+  var ENDPOINT = isDev ? 'https://person-api.sso.allizom.org/v1/connection/' : 'https://person-api.sso.mozilla.com/v1/connection/';
 
   if ( emailField.value === '' || emailField.validity.valid === false ) {
     emailField.focus();

--- a/src/js/handlers/enter.js
+++ b/src/js/handlers/enter.js
@@ -5,7 +5,7 @@ var isDev = require( 'helpers/isDev' );
 module.exports = function enter( element ) {
   var emailField = document.getElementById( 'field-email' );
   var passwordField = document.getElementById( 'field-password' );
-  var isDefinitelyLDAP = /mozilla.com|getpocket.com$/.test( emailField.value );
+  var isDefinitelyLDAP = /mozilla.com|getpocket.com|mozillafoundation.org$/.test( emailField.value );
   var ENDPOINT = isDev ? 'https://person-api.sso.allizom.org/v1/connection/' : 'https://person-api.sso.mozilla.com/v1/connection/';
 
   if ( emailField.value === '' || emailField.validity.valid === false ) {

--- a/src/js/handlers/send-passwordless-link.js
+++ b/src/js/handlers/send-passwordless-link.js
@@ -1,15 +1,19 @@
 var fireGAEvent = require( 'helpers/fireGAEvent' );
 var ui = require( 'helpers/ui' );
+var storeLastUsedConnection = require( 'helpers/storeLastUsedConnection' );
 
 module.exports = function authorise( element ) {
   var emailField = document.getElementById( 'field-email' );
   var form = element.form;
   var emailPlaceholder = document.getElementById( 'passwordless-success-email-address' );
   var errorText = document.getElementById( 'error-message-passwordless' );
+  var connection = 'email';
 
   ui.setLockState( element, 'loading' );
 
   fireGAEvent( 'Authorisation', 'Requested passwordless link' );
+
+  storeLastUsedConnection( connection );
 
   form.webAuth.passwordlessStart({
     connection: 'email',

--- a/src/js/helpers/isDev.js
+++ b/src/js/helpers/isDev.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  var host = window.location.host.toString();
+
+  return /^auth-dev/.test( host ) ? true : false;
+};

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,6 +4,9 @@ var handlers = require( 'handlers' );
 var decorators = require( 'decorators' );
 var polyfill = require( 'polyfills/polyfill' );
 
+window.Promise = require( 'promise-polyfill' );
+require( 'whatwg-fetch' );
+
 document.documentElement.className = 'has-js';
 
 polyfill();


### PR DESCRIPTION
## Cleanup

* Remove autologin decorator, as we no longer use it

## Tweaks

* Update banner text
* Add `@mozillafoundation.org` to LDAP quickcheck so that those addresses don't need to go to Person API
* Store connection for Passwordless

## New feature

* Distinguish between auth-dev and everything else. When on auth-dev, use staging Person API and staging LDAP. When anywhere else, use production Person API and production LDAP.
* IE10/IE11 support