### PR TITLE
Let autologin check available login methods for RP first

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -1,17 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-     <script>
-    /* Before doing anything else, let's try if we can login with the last used connection */
-    if ( window.location.hostname !== 'localhost' && window.localStorage ) {
-      var lastUsedConnection = window.localStorage.getItem( 'nlx-last-used-connection' );
-      var w = window.location.toString();
-
-      if ( lastUsedConnection && w.indexOf('tried_silent_auth=true') === -1 ) {
-        window.location = w.replace('/login?', '/authorize?').replace('?client=', '?client_id=') + '&sso=true&connection=' + lastUsedConnection + '&tried_silent_auth=true'
-      }
-    }
-     </script>
     <title>Mozilla Login</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="../../dist/css/styles.css" type="text/css" inline />

--- a/src/js/decorators/filter-connections.js
+++ b/src/js/decorators/filter-connections.js
@@ -24,6 +24,17 @@ module.exports = function( element ) {
       }
     });
 
+    if ( window.location.hostname !== 'localhost' && window.localStorage ) {
+      var lastUsedConnection = window.localStorage.getItem( 'nlx-last-used-connection' );
+      var w = window.location.toString();
+      var silentAuthEnabled = w.indexOf('tried_silent_auth=true') === -1;
+
+      if ( silentAuthEnabled && lastUsedConnection && allowedRPs.indexOf( lastUsedConnection ) >= 0 ) {
+        window.location = w.replace('/login?', '/authorize?').replace('?client=', '?client_id=') + '&sso=true&connection=' + lastUsedConnection + '&tried_silent_auth=true'
+        return
+      }
+    }
+
     ui.setLockState( element, 'initial' );
   }, function(){
     ui.setLockState( element, 'initial' );

--- a/src/js/decorators/filter-connections.js
+++ b/src/js/decorators/filter-connections.js
@@ -5,8 +5,6 @@ module.exports = function( element ) {
   var form = element.form;
   var url = 'https://auth-dev.mozilla.auth0.com/public/api/' + form.webAuthConfig.clientID + '/connections';
 
-  ui.setLockState( element, 'loading' );
-
   fetch( url ).then( function( response ) {
     return response.json();
   }).then( function( allowed ) {


### PR DESCRIPTION
This changes the flow slightly: autologin will now happen only _after_ the check for available login methods.

It means that people will always see a spinner, this is while we're deciding whether to autologin or not (spinner time is~  the time that it takes to get our request back from Auth0's API).