### PR TITLE
add environment var support for prod vs dev in npm run build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ If you want to build the page just once, for example to deploy it, run:
 npm run build
 ```
 
+> Note: in order to build the production configuration you should run `export NODE_ENV=production` otherwise this will default to the dev environment.
+
 ### Viewing/developing locally
 
 To view (and develop) locally, this project has a server built in. To compile the sources and serve them, run:

--- a/config/development.json
+++ b/config/development.json
@@ -1,0 +1,7 @@
+{
+  "auth0_domain" : "https://auth-dev.mozilla.auth0.com",
+  "LDAP_connection_name" : "Mozilla-LDAP-Dev",
+  "person_api_domain" : "https://person-api.sso.allizom.org/connection",
+  "GTM_ID": "GTM-T2N2BRW",
+  "client_id": "CIynn5wTPyYZQcA1FJx1Io9z4t7QWDaE"
+}

--- a/config/production.json
+++ b/config/production.json
@@ -1,0 +1,6 @@
+{
+  "auth0_domain" : "https://auth.mozilla.auth0.com",
+  "LDAP_connection_name" : "Mozilla-LDAP",
+  "person_api_domain" : "https://person-api.allizom.org/connection",
+  "GTM_ID": "GTM-T2N2BRW"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,26 +24,15 @@ const paths = {
   drop : 'dist'
 };
 
-const config = {
-  'local': {
-    'lock' : {
-      'auth0_domain' : 'https://auth-dev.mozilla.auth0.com',
-      'LDAP_connection_name' : 'Mozilla-LDAP-Dev',
-      'person_api_domain' : 'https://person-api.mozilla.com/connection',
-      'GTM_ID': 'GTM-T2N2BRW',
-      'client_id': 'CIynn5wTPyYZQcA1FJx1Io9z4t7QWDaE'
-    }
-  },
-  'production': {
-    'lock' : {
-      'auth0_domain' : 'https://auth.mozilla.auth0.com',
-      'LDAP_connection_name' : 'Mozilla-LDAP',
-      'person_api_domain' : 'https://person-api.allizom.org/connection',
-      'GTM_ID': 'GTM-T2N2BRW'
-    }
-  }
-};
+const environment = process.env.NODE_ENV || 'development'
 
+var fs = require('fs');
+const config = JSON.parse(fs.readFileSync('config/' + environment.toLowerCase() + '.json', 'utf8'));
+
+console.log('Production environment identified.  Building NLX with production config:')
+console.log('---------------------------Begin configuration.---------------------------')
+console.log(config);
+console.log('---------------------------End configuration.---------------------------')
 
 /* -----------------------------------
    Tasks
@@ -67,7 +56,7 @@ gulp.task( 'process-html', function() {
 
   return gulp.src( paths.html + '/*.html' )
     .pipe( inlinesource( options.inlineSource ) )
-    .pipe( mustache( config.local ) )
+    .pipe( mustache( config ) )
     .pipe( gulp.dest( paths.drop ) )
     .pipe( browserSync.reload( { stream: true } ));
 });

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -17,11 +17,11 @@ This is the custom Mozilla Login Experience.
 
 These are the variables we are using:
 
-  Auth0-domain: {{{ lock.auth0_domain }}}
-  Client ID: {{{ lock.client_id }}}
-  LDAP connection name: {{{ lock.LDAP_connection_name }}}
-  Person API domain: {{{ lock.person_api_domain }}}
-  Google Tag Manager ID: {{{ lock.GTM_ID }}}
+  Auth0-domain: {{{ auth0_domain }}}
+  Client ID: {{{ client_id }}}
+  LDAP connection name: {{{ LDAP_connection_name }}}
+  Person API domain: {{{ person_api_domain }}}
+  Google Tag Manager ID: {{{ GTM_ID }}}
 -->
 <!DOCTYPE html>
 <html lang="en">

--- a/src/js/decorators/filter-connections.js
+++ b/src/js/decorators/filter-connections.js
@@ -4,7 +4,7 @@ var fireGAEvent = require( 'helpers/fireGAEvent' );
 
 module.exports = function( element ) {
   var form = element.form;
-  var url = '{{ lock.auth0domain }}' + '/public/api/' + form.webAuthConfig.clientID + '/connections';
+  var url = '{{ auth0domain }}' + '/public/api/' + form.webAuthConfig.clientID + '/connections';
 
   ui.setLockState( element, 'loading' );
 

--- a/src/js/decorators/init-auth.js
+++ b/src/js/decorators/init-auth.js
@@ -12,8 +12,8 @@ function getConfig( string ) {
     config = Object.assign( config, hostedConfig.internalOptions );
   }
   else {
-    config.domain = '{{{ lock.auth0_domain }}}';
-    config.clientID = '{{{ lock.client_id }}}';
+    config.domain = '{{{ auth0_domain }}}';
+    config.clientID = '{{{ client_id }}}';
   }
   return config;
 }

--- a/src/js/decorators/load-ga.js
+++ b/src/js/decorators/load-ga.js
@@ -9,7 +9,7 @@ module.exports = function() {
   if ( dntEnabled === false ) {
     firstScriptTag = document.getElementsByTagName( 'script' )[0];
     scriptTag = document.createElement( 'script' );
-    ID = '{{{ lock.GTM_ID }}}';
+    ID = '{{{ GTM_ID }}}';
 
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({

--- a/src/js/handlers/authorise-ldap.js
+++ b/src/js/handlers/authorise-ldap.js
@@ -7,7 +7,7 @@ module.exports = function authorise( element, secondTry ) {
   var emailField = document.getElementById( 'field-email' );
   var passwordField = secondTry ? document.getElementById( 'field-password-try-2' ) : document.getElementById( 'field-password' );
   var errorText = document.getElementById( 'error-message-ldap' );
-  var connection = '{{{ lock.LDAP_connection_name }}}';
+  var connection = '{{{ LDAP_connection_name }}}';
 
   if ( element.id === 'authorise-ldap-credentials-try-2' ) {
     passwordField = document.getElementById( 'field-password-try-2' );


### PR DESCRIPTION
This adds support for setting `NODE_ENV` for values:

* Production || production
* Development || development 

Abstracts configuration to JSON files in the project.  
Update mustache to eliminate use of the word "lock"
