### PR TITLE
Release 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,22 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2018-03-26
+
+### Added
+
+- Add polyfill for localStorage so that NLX works in browsers that don't support it
+  (including Android Webviews)
+
+## [1.1.3] - 2018-03-22
+
+- Remove `prompt` support for autologin as it gets forwarded to Social providers in some cases, which may fail the entire login process.
+
 ## [1.1.2] - 2018-03-21
 
-## Changed
+### Changed
 
 - Uses Auth0js v9.3.3
-- Remove `prompt` support for autologin as it gets forwarded to Social providers in some cases, which may fail the entire login process.
 
 ## [1.1.1] - 2018-03-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lock",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "The front-end for Mozilla's Auth0 Lock",
   "main": "index.js",
   "scripts": {

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -15,7 +15,7 @@ vVVv    vVVv                 ': |_| |_| |_|\___/___|_|_|_|\__,_| ''
 
 This is the custom Mozilla Login Experience, designed and built by Mozilla's IAM Project.
 
-Version: 1.1.3
+Version: 1.1.4
 Changelog: https://github.com/mozilla-iam/auth0-custom-lock/blob/master/CHANGELOG.md
 
 These are the variables we are using:

--- a/src/js/polyfills/polyfill.js
+++ b/src/js/polyfills/polyfill.js
@@ -71,7 +71,78 @@ module.exports = function() {
       return null;
     };
   }
-};
+
+if (!window.localStorage) {
+  Object.defineProperty(window, "localStorage", new (function () {
+    var aKeys = [], oStorage = {};
+    Object.defineProperty(oStorage, "getItem", {
+      value: function (sKey) { return sKey ? this[sKey] : null; },
+      writable: false,
+      configurable: false,
+      enumerable: false
+    });
+    Object.defineProperty(oStorage, "key", {
+      value: function (nKeyId) { return aKeys[nKeyId]; },
+      writable: false,
+      configurable: false,
+      enumerable: false
+    });
+    Object.defineProperty(oStorage, "setItem", {
+      value: function (sKey, sValue) {
+        if(!sKey) { return; }
+        document.cookie = escape(sKey) + "=" + escape(sValue) + "; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/";
+      },
+      writable: false,
+      configurable: false,
+      enumerable: false
+    });
+    Object.defineProperty(oStorage, "length", {
+      get: function () { return aKeys.length; },
+      configurable: false,
+      enumerable: false
+    });
+    Object.defineProperty(oStorage, "removeItem", {
+      value: function (sKey) {
+        if(!sKey) { return; }
+        document.cookie = escape(sKey) + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+      },
+      writable: false,
+      configurable: false,
+      enumerable: false
+    });
+    Object.defineProperty(oStorage, "clear", {
+      value: function () {
+        if(!aKeys.length) { return; }
+        for (var sKey in aKeys) {
+          document.cookie = escape(sKey) + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+        }
+      },
+      writable: false,
+      configurable: false,
+      enumerable: false
+    });
+    this.get = function () {
+      var iThisIndx;
+      for (var sKey in oStorage) {
+        iThisIndx = aKeys.indexOf(sKey);
+        if (iThisIndx === -1) { oStorage.setItem(sKey, oStorage[sKey]); }
+        else { aKeys.splice(iThisIndx, 1); }
+        delete oStorage[sKey];
+      }
+      for (aKeys; aKeys.length > 0; aKeys.splice(0, 1)) { oStorage.removeItem(aKeys[0]); }
+      for (var aCouple, iKey, nIdx = 0, aCouples = document.cookie.split(/\s*;\s*/); nIdx < aCouples.length; nIdx++) {
+        aCouple = aCouples[nIdx].split(/\s*=\s*/);
+        if (aCouple.length > 1) {
+          oStorage[iKey = unescape(aCouple[0])] = unescape(aCouple[1]);
+          aKeys.push(iKey);
+        }
+      }
+      return oStorage;
+    };
+    this.configurable = false;
+    this.enumerable = true;
+  })());
+}};
 
 /*
  * Copyright 2015 Google Inc. All rights reserved.

--- a/src/js/polyfills/polyfill.js
+++ b/src/js/polyfills/polyfill.js
@@ -72,6 +72,8 @@ module.exports = function() {
     };
   }
 
+// localStorage (from MDN:
+// https://developer.mozilla.org/en-US/docs/Web/API/Storage/LocalStorage)
 if (!window.localStorage) {
   Object.defineProperty(window, "localStorage", new (function () {
     var aKeys = [], oStorage = {};

--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -21,6 +21,7 @@
     text-transform: capitalize;
     padding-left: 2.125em;
     position: relative;
+    min-height: 1.5em;
 
     svg {
       width: 1.5em;


### PR DESCRIPTION
* Added polyfill for localStorage (this fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1448284)
* Did a quick fix that makes sure the heading in an error page always takes up some space (it seems that new Auth0.js throws errors differently, the headings are no longer passed the same way)