### PR TITLE
Add supported login methods to PROD config

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -8,5 +8,6 @@
   "features": {
     "autologin": "true",
     "person_api_lookup": "true"
-  }
+  },
+  "supportedLoginMethods": [ "github", "google-oauth2", "email" ]
 }


### PR DESCRIPTION
@gdestuynder Hi Guillaume, I noticed the supported login methods were missing in PROD config, we should merge this is in before building the new PROD NLX.