### PR TITLE
Use the URL object's searchParams to contruct the redirect URL (mor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use the URL object's searchParams to contruct the redirect URL (more reliable)
+- Remove `prompt` if not set, so that OIDC OP that do not support it don't get confused
+
 ### Added
 
 - Firefox Accounts support, pref'd off for production, see also

--- a/src/js/helpers/autologin.js
+++ b/src/js/helpers/autologin.js
@@ -3,11 +3,24 @@ var fireGAEvent = require( 'helpers/fire-ga-event' );
 module.exports = function autologin( loginMethod, form ) {
   var visualStatusReport = document.getElementById( 'loading__status' );
   var newLocation;
+  var url = new URL(document.location);
+  var params = myurl.searchParams;
 
   form.willRedirect = true;
   visualStatusReport.textContent = 'Autologging in with ' + loginMethod;
 
-  newLocation = window.location.toString().replace( '/login?', '/authorize?' ).replace( '?client=', '?client_id=' ) + '&sso=true&connection=' + loginMethod + '&tried_autologin=true';
+  params.set('sso', 'true');
+  params.set('connection', loginMethod);
+  params.set('tried_autologin', 'true');
+  params.set('client_id', myparams.get('client'));
+  params.delete('client');
+
+  // Remove 'prompt=&blah=...' where prompt is empty as this confuses OPs that do not support the OPTIONAL `prompt`
+  // parameter, such as FxA
+  if (params.get('prompt') === '') {
+    params.delete('prompt');
+  }
+  newLocation = url.origin + myurl.pathname.replace( '/login', '/authorize' ) + '?' + params.toString();
 
   window.location.replace( newLocation );
   fireGAEvent( 'Authorisation', 'Performing auto-login with ' + loginMethod );


### PR DESCRIPTION
…e reliable)

- Remove `prompt` if not set, so that OIDC OP that do not support it don't get confused

(Replaces #126, merging to development first, then will PR to master at once, before release)