### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased [1.2.1]
+
+### Added
+
+- Added URL.searchParams polyfill
+
+### Changed
+
+- Autologin URL transformation now happens with `URL.searchParams`.
+
 ## [1.2.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,22 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased [1.2.1]
+## [1.2.1]
 
 ### Added
 
-- Added URL.searchParams polyfill
+- Added `URL.searchParams` polyfill
 
 ### Changed
 
-- Autologin URL transformation now happens with `URL.searchParams`.
+- Use the URL object's `searchParams` to contruct the redirect URL (more reliable)
+- Remove `prompt` if not set, so that OIDC OP that do not support it don't get confused
 
 ## [1.2.0]
-
-### Changed
-
-- Use the URL object's searchParams to contruct the redirect URL (more reliable)
-- Remove `prompt` if not set, so that OIDC OP that do not support it don't get confused
 
 ### Added
 

--- a/config/production.json
+++ b/config/production.json
@@ -8,5 +8,6 @@
   "features": {
     "autologin": "true",
     "person_api_lookup": "true"
-  }
+  },
+  "supportedLoginMethods": [ "github", "google-oauth2", "email" ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lock",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The front-end for Mozilla's Auth0 Lock",
   "main": "index.js",
   "scripts": {
@@ -24,6 +24,7 @@
   "dependencies": {
     "auth0-js": "^9.3.3",
     "promise-polyfill": "^6.0.2",
+    "url-search-params-polyfill": "^3.0.0",
     "whatwg-fetch": "^2.0.3"
   }
 }

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -55,9 +55,11 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet">
   </head>
   <body data-decorator="load-ga display-rp-name">
+    <!--
     <div class="banner">
-      <p>We have launched and are actively testing the new login experience. Please report any issues. <a href="https://discourse.mozilla.org/t/important-changing-the-look-of-your-login/25843" class="banner__button" target="_blank">Read more</a> <a href="https://wiki.mozilla.org/IAM/Frequently_asked_questions#New_Login_Experience_FAQ_.28Frequently_Asked_Questions.29" class="banner__button" target="_blank">FAQ</a></p>
+      <p></p>
     </div>
+    -->
     <div class="card">
       <a href="https://mozilla.org" class="logo" target="_blank"><img alt="Mozilla" src="../images/mozilla.svg" inline /></a>
       <noscript><p>This login form requires JavaScript to work, please enable it to log in.</p></noscript>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -15,7 +15,7 @@ vVVv    vVVv                 ': |_| |_| |_|\___/___|_|_|_|\__,_| ''
 
 This is the custom Mozilla Login Experience, designed and built by Mozilla's IAM Project.
 
-Version: 1.2.0
+Version: 1.2.1
 Changelog: https://github.com/mozilla-iam/auth0-custom-lock/blob/master/CHANGELOG.md
 
 These are the variables we are using:

--- a/src/js/helpers/autologin.js
+++ b/src/js/helpers/autologin.js
@@ -3,26 +3,29 @@ var fireGAEvent = require( 'helpers/fire-ga-event' );
 module.exports = function autologin( loginMethod, form ) {
   var visualStatusReport = document.getElementById( 'loading__status' );
   var newLocation;
-  var url = new URL(document.location);
+  var url = new URL( document.location );
   var params = url.searchParams;
 
   form.willRedirect = true;
   visualStatusReport.textContent = 'Attempting auto-login with ' + loginMethod;
 
-  params.set('sso', 'true');
-  params.set('connection', loginMethod);
-  params.set('tried_autologin', 'true');
-  params.set('client_id', myparams.get('client'));
-  params.delete('client');
+  params.set( 'sso', 'true' );
+  params.set( 'connection', loginMethod );
+  params.set( 'tried_autologin', 'true' );
+  params.set( 'client_id', params.get( 'client' ) );
+  params.delete( 'client' );
 
   // Remove 'prompt=&blah=...' where prompt is empty as this confuses OPs that do not support the OPTIONAL `prompt`
   // parameter, such as FxA
-  if (params.get('prompt') === '') {
-    params.delete('prompt');
+  if ( params.get( 'prompt' ) === '' ) {
+    params.delete( 'prompt' );
   }
-  newLocation = url.origin + myurl.pathname.replace( '/login', '/authorize' ) + '?' + params.toString();
+
+  newLocation = url.origin + url.pathname.replace( '/login', '/authorize' ) + '?' + params.toString();
 
   window.location.replace( newLocation );
+
   fireGAEvent( 'Authorisation', 'Performing auto-login with ' + loginMethod );
+
   return;
 };

--- a/src/js/helpers/autologin.js
+++ b/src/js/helpers/autologin.js
@@ -4,7 +4,7 @@ module.exports = function autologin( loginMethod, form ) {
   var visualStatusReport = document.getElementById( 'loading__status' );
   var newLocation;
   var url = new URL(document.location);
-  var params = myurl.searchParams;
+  var params = url.searchParams;
 
   form.willRedirect = true;
   visualStatusReport.textContent = 'Attempting auto-login with ' + loginMethod;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -6,6 +6,8 @@ var polyfill = require( 'polyfills/polyfill' );
 
 window.Promise = require( 'promise-polyfill' );
 require( 'whatwg-fetch' );
+require( 'url-search-params-polyfill' );
+polyfill();
 
 document.documentElement.className = 'has-js';
 
@@ -23,8 +25,6 @@ window.NLX = {
   },
   'supportedLoginMethods': [ 'github', 'google-oauth2', 'firefoxaccounts', 'email' ]
 };
-
-polyfill();
 
 // run all decorators on page load
 decorate( decorators );


### PR DESCRIPTION
HI @gdestuynder, these are basically your changes, now with polyfill and up to date with latest version.

Changes to autologin URL construction: 

* Use the URL object's searchParams to contruct the redirect URL (more reliable)
* Remove `prompt` if not set, so that OIDC OP that do not support it don't get confused
* Tweak whitespace to please linter; also updated var names

Other:

* Update changelog
* Hide banner