### PR TITLE
GTM msg for triedAutologin

### DIFF
--- a/src/js/decorators/filter-connections.js
+++ b/src/js/decorators/filter-connections.js
@@ -57,6 +57,8 @@ module.exports = function( element ) {
       if ( !didAccountLinking && !triedAutologin && autologinEnabled && rpSupportsSavedLoginMethod ) {
         autologin( savedLoginMethod, form );
         return;
+      } else if (triedAutoLogin && autologinEnabled && rpSupportsSavedLoginMethod) {
+        fireGAEvent( 'Authorisation', 'Autologin did not succeed with ' + loginMethod );
       }
     });
 


### PR DESCRIPTION
GTM msg for triedAutologin adds a message that we can lookup in GTM telling us when autologin failed (for any reason, session expiration, logout, brokeneness, etc.) note: should this if condition include account linking? Not 100% sure what it does

Also: we should verify we have a message when we hit the logout variable as well, its useful for debug/understanding of users flow