### PR TITLE
Add autologin toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<<<<<<< HEAD
-
 ## [Unreleased; 1.3.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+<<<<<<< HEAD
+
+## [Unreleased; 1.3.0]
+
+### Added
+
+- Added auto-login switch
+- Added hidden auto-login settings screen
+
 ## [1.2.1]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lock",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "The front-end for Mozilla's Auth0 Lock",
   "main": "index.js",
   "scripts": {

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -98,7 +98,7 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             </ul>
             <hr>
             <div class="setting">
-              <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference">
+              <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference" checked>
               <label for="use-autologin"><span class="setting__toggle"></span> Use auto-login</label>
             </div>
           </div>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -96,6 +96,11 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
                   <span><span class="visually-hidden">Log in with </span>Google</span>
                 </button>
             </ul>
+            <hr>
+            <div class="setting">
+              <input type="checkbox" id="use-autologin">
+              <label for="use-autologin"><span class="setting__toggle"></span> Use auto-login</label>
+            </div>
           </div>
           <div id="ldap" data-screen data-hidden aria-hidden inert>
             <p>Please enter your LDAP password:</p>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -122,19 +122,19 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
               <li data-optional-login-method="firefoxaccounts">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-firefoxaccounts">
                   <img inline  class="icon" src="../images/firefox.svg">
-                  <span>Log in with Firefox Accounts</span>
+                  <span>Firefox Accounts</span>
                 </button>
               </li>
               <li data-optional-login-method="github">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-github">
                   <img inline class="icon" src="../images/github.svg">
-                  <span>Log in with GitHub</span>
+                  <span>GitHub</span>
                 </button>
               </li>
               <li data-optional-login-method="google-oauth2">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-google">
                   <img inline  class="icon" src="../images/google.svg">
-                  <span>Log in with Google</span>
+                  <span>Google</span>
                 </button>
             </ul>
             <hr>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -66,12 +66,23 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
       <form data-decorator="init-auth handle-submit" method="post" action="/" lock-state="initial">
         <fieldset data-decorator="filter-connections">
           <legend class="rp-name"><span class="visually-hidden">Log in to </span><span id="rp-name-placeholder" class="rp-name__text"></span></legend>
-          <div id="loading" class="loading" data-screen>
+          <div id="loading" class="loading" data-screen data-hidden aria-hidden inert>
             <p class="visually-hidden ">Loading…</p>
             <img src="../images/loading.svg" class="loading__spinner" inline />
             <p role="alert" id="loading__status" class="loading__status"></p>
           </div>
-          <div id="initial" data-screen data-hidden aria-hidden inert>
+<!--           <div id="preferences">
+            <h2 class="card__heading card__heading--iconless">Auto-login settings</h2>
+            <p>You are currently logged in as <strong>hidde@hiddedevries.nl</strong> using <strong>Github</strong>.</p>
+            <div class="setting">
+              <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference" checked>
+              <label for="use-autologin"><span class="setting__toggle"></span> Auto-login is <strong>On</strong></label>
+            </div>
+            <hr>
+            <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to log in with a different account?</button>
+          </div>
+ -->
+          <div id="initial" data-screen data-hidden aria-hidden>
             <p>Log in with email:</p>
             <label for="field-email" class="visually-hidden">E-mail address</label>
             <input type="email" name="username" id="field-email" placeholder="Email address" autocomplete="username email" autofocus />

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -99,7 +99,7 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             <hr>
             <div class="setting">
               <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference" checked>
-              <label for="use-autologin"><span class="setting__toggle"></span> Use auto-login</label>
+              <label for="use-autologin"><span class="setting__toggle"></span> <span class="setting__enabled-text">Disable Auto-login</span><span class="setting__disabled-text">Enable Auto-login</span></label>
             </div>
           </div>
           <div id="ldap" data-screen data-hidden aria-hidden inert>
@@ -178,8 +178,8 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             <h2 class="card__heading card__heading--iconless">Auto-login settings</h2>
             <p>You are currently logged in as <strong>hidde@hiddedevries.nl</strong> using <strong>Github</strong>.</p>
             <div class="setting">
-              <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference" checked>
-              <label for="use-autologin"><span class="setting__toggle"></span> Auto-login is <strong>On</strong></label>
+              <input type="checkbox" id="use-autologin-2" data-decorator="set-autologin-preference" checked>
+              <label for="use-autologin-2" toggle-text=""><span class="setting__toggle"></span> <span class="setting__enabled-text">Disable Auto-login</span><span class="setting__disabled-text">Enable Auto-login</span></label>
             </div>
             <hr>
             <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to log in with a different account?</button>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -64,24 +64,13 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
       <a href="https://mozilla.org" class="logo" target="_blank"><img alt="Mozilla" src="../images/mozilla.svg" inline /></a>
       <noscript><p>This login form requires JavaScript to work, please enable it to log in.</p></noscript>
       <form data-decorator="init-auth handle-submit" method="post" action="/" lock-state="initial">
-        <fieldset data-decorator="filter-connections">
+        <fieldset data-decorator="decide-screen">
           <legend class="rp-name"><span class="visually-hidden">Log in to </span><span id="rp-name-placeholder" class="rp-name__text"></span></legend>
           <div id="loading" class="loading" data-screen data-hidden aria-hidden inert>
             <p class="visually-hidden ">Loading…</p>
             <img src="../images/loading.svg" class="loading__spinner" inline />
             <p role="alert" id="loading__status" class="loading__status"></p>
           </div>
-<!--           <div id="preferences">
-            <h2 class="card__heading card__heading--iconless">Auto-login settings</h2>
-            <p>You are currently logged in as <strong>hidde@hiddedevries.nl</strong> using <strong>Github</strong>.</p>
-            <div class="setting">
-              <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference" checked>
-              <label for="use-autologin"><span class="setting__toggle"></span> Auto-login is <strong>On</strong></label>
-            </div>
-            <hr>
-            <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to log in with a different account?</button>
-          </div>
- -->
           <div id="initial" data-screen data-hidden aria-hidden>
             <p>Log in with email:</p>
             <label for="field-email" class="visually-hidden">E-mail address</label>
@@ -182,6 +171,16 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
           <div id="ldap-required" data-screen data-hidden aria-hidden inert>
             <h2 class="card__heading card__heading--error"><img src="../images/circled-x.svg" class="card__heading-icon" inline /> <span>Error</span></h2>
             <p>Unfortunately, you can only login to this website using Mozilla LDAP.</p>
+            <hr>
+            <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to log in with a different account?</button>
+          </div>
+          <div id="autologin-settings" data-screen data-hidden aria-hidden inert>
+            <h2 class="card__heading card__heading--iconless">Auto-login settings</h2>
+            <p>You are currently logged in as <strong>hidde@hiddedevries.nl</strong> using <strong>Github</strong>.</p>
+            <div class="setting">
+              <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference" checked>
+              <label for="use-autologin"><span class="setting__toggle"></span> Auto-login is <strong>On</strong></label>
+            </div>
             <hr>
             <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to log in with a different account?</button>
           </div>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -98,7 +98,7 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             </ul>
             <hr>
             <div class="setting">
-              <input type="checkbox" id="use-autologin">
+              <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference">
               <label for="use-autologin"><span class="setting__toggle"></span> Use auto-login</label>
             </div>
           </div>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -15,7 +15,7 @@ vVVv    vVVv                 ': |_| |_| |_|\___/___|_|_|_|\__,_| ''
 
 This is the custom Mozilla Login Experience, designed and built by Mozilla's IAM Project.
 
-Version: 1.2.1
+Version: 1.3.0
 Changelog: https://github.com/mozilla-iam/auth0-custom-lock/blob/master/CHANGELOG.md
 
 These are the variables we are using:
@@ -51,8 +51,8 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
       window.location.replace( '{{{ logout_url }}}' );
     }
     </script>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet">
     <link href="../../dist/css/styles.css" type="text/css" inline />
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet">
   </head>
   <body data-decorator="load-ga display-rp-name">
     <!--

--- a/src/js/decorators.js
+++ b/src/js/decorators.js
@@ -8,7 +8,8 @@ var decorators = {
   'load-ga': require( 'decorators/load-ga' ),
   'handle-submit': require( 'decorators/handle-submit' ),
   'display-rp-name': require( 'decorators/display-rp-name' ),
-  'filter-connections': require( 'decorators/filter-connections' )
+  'filter-connections': require( 'decorators/filter-connections' ),
+  'set-autologin-preference': require( 'decorators/set-autologin-preference' )
 };
 
 module.exports = decorators;

--- a/src/js/decorators.js
+++ b/src/js/decorators.js
@@ -3,13 +3,14 @@
 // decorators are functions that run when the page loads
 
 var decorators = {
-  'init-auth': require( 'decorators/init-auth' ),
-  'submit-with-enter': require( 'decorators/submit-with-enter' ),
-  'load-ga': require( 'decorators/load-ga' ),
-  'handle-submit': require( 'decorators/handle-submit' ),
+  'decide-screen': require( 'decorators/decide-screen'),
   'display-rp-name': require( 'decorators/display-rp-name' ),
   'filter-connections': require( 'decorators/filter-connections' ),
-  'set-autologin-preference': require( 'decorators/set-autologin-preference' )
+  'handle-submit': require( 'decorators/handle-submit' ),
+  'init-auth': require( 'decorators/init-auth' ),
+  'load-ga': require( 'decorators/load-ga' ),
+  'set-autologin-preference': require( 'decorators/set-autologin-preference' ),
+  'submit-with-enter': require( 'decorators/submit-with-enter' )
 };
 
 module.exports = decorators;

--- a/src/js/decorators/decide-screen.js
+++ b/src/js/decorators/decide-screen.js
@@ -1,0 +1,13 @@
+var filterConnections = require( 'decorators/filter-connections' );
+var ui = require( 'helpers/ui' );
+var hasParams = require( 'helpers/has-params' );
+
+module.exports = function decideScreen( element ) {
+
+  if ( hasParams( 'action=autologin_settings' ) ) {
+    ui.setLockState( element, 'autologin-settings' );
+  }
+  else {
+    filterConnections( element );
+  }
+};

--- a/src/js/decorators/set-autologin-preference.js
+++ b/src/js/decorators/set-autologin-preference.js
@@ -6,6 +6,11 @@ module.exports = function setAutologinPreference( element ) {
     checkbox.checked = true;
   }
 
+  if ( localStorage.getItem( 'nlx-prevent-autologin' ) !== null  ) {
+    checkbox.checked = false;
+  }
+
+
   checkbox.addEventListener( 'change', function() {
     // when autologin is turned OFF, remove last used connection,
     // prevent autologin method from being stored next time

--- a/src/js/decorators/set-autologin-preference.js
+++ b/src/js/decorators/set-autologin-preference.js
@@ -2,11 +2,13 @@ module.exports = function setAutologinPreference( element ) {
   var checkbox = element;
 
   // when page loads, make sure checkbox matches autologin setting
+  // (one of these two is not needed, depending on whether page has
+  // 'checked' attribute on the checkbox)
   if ( localStorage.getItem( 'nlx-last-used-connection' ) !== null ) {
     checkbox.checked = true;
   }
 
-  if ( localStorage.getItem( 'nlx-prevent-autologin' ) !== null  ) {
+  if ( localStorage.getItem( 'nlx-prevent-autologin' ) !== null ) {
     checkbox.checked = false;
   }
 

--- a/src/js/decorators/set-autologin-preference.js
+++ b/src/js/decorators/set-autologin-preference.js
@@ -1,0 +1,22 @@
+module.exports = function setAutologinPreference( element ) {
+  var checkbox = element;
+
+  // when page loads, make sure checkbox matches autologin setting
+  if ( localStorage.getItem( 'nlx-last-used-connection' ) !== null ) {
+    checkbox.checked = true;
+  }
+
+  checkbox.addEventListener( 'change', function() {
+    // when autologin is turned OFF, remove last used connection,
+    // prevent autologin method from being stored next time
+    if ( checkbox.checked === false ) {
+      localStorage.removeItem( 'nlx-last-used-connection' );
+      localStorage.setItem( 'nlx-prevent-autologin', 'true' );
+    }
+    // when autologin is tuned ON, no longer prevent autologin
+    // method from being set
+    else {
+      localStorage.removeItem( 'nlx-prevent-autologin' );
+    }
+  });
+};

--- a/src/js/handlers/authorise-ldap.js
+++ b/src/js/handlers/authorise-ldap.js
@@ -26,7 +26,7 @@ module.exports = function authorise( element, secondTry ) {
     realm: connection,
     username: emailField.value.toLowerCase(),
     password: passwordField.value
-  }, function ( error ) {
+  }, function( error ) {
     errorText.lastElementChild.textContent = error.description;
     ui.setLockState( element, 'error-password' );
     fireGAEvent( 'Error', 'LDAP: invalid username or password' );

--- a/src/js/helpers/has-params.js
+++ b/src/js/helpers/has-params.js
@@ -1,0 +1,3 @@
+module.exports = function hasParams( string ) {
+  return window.location.href.indexOf( string ) >= 0;
+};

--- a/src/js/helpers/store-last-used-connection.js
+++ b/src/js/helpers/store-last-used-connection.js
@@ -1,9 +1,10 @@
-var accountLinking = require( 'helpers//account-linking' );
+var accountLinking = require( 'helpers/account-linking' );
 
 module.exports = function( connectionName ) {
   var isAccountLinking = accountLinking.isAccountLinking();
+  var preventAutologin = localStorage.getItem( 'nlx-prevent-autologin' ) !== null;
 
-  if ( !isAccountLinking && window.localStorage ) {
+  if ( !isAccountLinking && !preventAutologin ) {
     window.localStorage.setItem( 'nlx-last-used-connection', connectionName );
   }
 };

--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -31,6 +31,10 @@
     position: relative;
     min-height: 1.5em;
 
+    &--iconless {
+      padding-left: 0;
+    }
+
     svg {
       width: 1.5em;
       height: 1.5em;

--- a/src/scss/components/_setting.scss
+++ b/src/scss/components/_setting.scss
@@ -1,0 +1,48 @@
+.setting {
+
+  input {
+    position: absolute;
+    left: -9999em;
+
+    &:focus + label span {
+      border: 1px dotted;
+    }
+  }
+
+  label {
+    margin: 0;
+  }
+
+  &__toggle {
+    width: 3em;
+    height: 1.75em;
+    border-radius: 1em;
+    background-color: $midGrey;
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: .5em;
+    position: relative;
+    border: 1px solid transparent;
+
+    input:checked + label & {
+      background-color: $green;
+    }
+
+    &::after {
+      transition: all 0.2s ease-in-out;
+      position: absolute;
+      width: 1.5em;
+      height: 1.5em;
+      border-radius: 1em;
+      content: '';
+      top: .05em;
+      left: 1.375em;
+      background-color: white;
+
+      input:checked + label & {
+        left: .125em;
+      }
+    }
+  }
+
+}

--- a/src/scss/components/_setting.scss
+++ b/src/scss/components/_setting.scss
@@ -13,6 +13,22 @@
     margin: 0;
   }
 
+  &__disabled-text {
+    display: inline;
+
+    input:checked + label & {
+      display: none;
+    }
+  }
+
+  &__enabled-text {
+    display: none;
+
+    input:checked + label & {
+      display: inline;
+    }
+  }
+
   &__toggle {
     width: 3em;
     height: 1.75em;

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -28,4 +28,4 @@ $red: #ff4f5e;
 @import 'components/login-options';
 @import 'components/logo';
 @import 'components/rp-name';
-
+@import 'components/setting';


### PR DESCRIPTION
## New screen: ‘Auto-login settings’

It shows when the NLX URL has parameter `action=autologin_settings`. It lets user see what they're logged in with and lets them set auto-login to on or off.

## New logic

Before filtering connections and displaying the initial screen, we now first run the `decide-screen` function, which can decide on showing a different screen based on parameters that exist.