### PR TITLE
Remove CSP meta tag for now

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -52,13 +52,6 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
     }
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="Content-Security-Policy" content="
-      default-src 'none';
-      connect-src 'self' https://person-api.sso.mozilla.com/v1/connection/;
-      font-src https://fonts.gstatic.com;
-      script-src 'unsafe-inline';
-      style-src 'unsafe-inline' https://fonts.googleapis.com/
-    ">
     <link href="../../dist/css/styles.css" type="text/css" inline />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet">
   </head>


### PR DESCRIPTION
So that we can QA it properly and make sure it really includes all the sources we need.