### PR TITLE
Undo inert polyfill's CSS as it fails CSP

### DIFF
--- a/src/js/polyfills/polyfill.js
+++ b/src/js/polyfills/polyfill.js
@@ -186,18 +186,6 @@ if (!('inert' in HTMLElement.prototype)) {
   });
 
   window.addEventListener('load', function() {
-    function applyStyle(css) {
-      var style = document.createElement('style');
-      style.type = 'text/css';
-      if (style.styleSheet) {
-        style.styleSheet.cssText = css;
-      } else {
-        style.appendChild(document.createTextNode(css));
-      }
-      document.body.appendChild(style);
-    }
-    var css = "/*[inert]*/*[inert]{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;pointer-events:none}";
-    applyStyle(css);
 
     /**
      * Sends a fake tab event. This is only supported by some browsers.

--- a/src/scss/generic/_typography.scss
+++ b/src/scss/generic/_typography.scss
@@ -28,6 +28,14 @@ body {
   opacity: 0;
 }
 
+[inert] {
+  -webkit-user-select:none;
+  -moz-user-select:none;
+  -ms-user-select:none;
+  user-select:none;
+  pointer-events:none;
+}
+
 h1 {
   margin: 0;
 }


### PR DESCRIPTION
@kang sorry, one more thing to add to tonight's deploy, as a polyfill was inlining CSS, I'm now adding that through the actual stylesheet, so that it doesn't trigger a CSP violation