### PR TITLE
Fix dependency on packages with vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gulp-minify": "^3.0.2",
     "gulp-mustache": "^3.0.1",
     "gulp-sass": "^3.2.1",
+    "node-sass": "^4.9.3",
     "gulp-sourcemaps": "^2.6.4",
     "gulp-uglify": "^3.0.0",
     "gulplog": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "browser-sync": "^2.24.4",
     "browserify": "^14.3.0",
+    "cached-path-relative": "^1.0.2",
     "del": "^2.2.2",
     "eslint": "^3.13.1",
     "gulp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Hidde de Vries",
   "license": "MPL-2.0",
   "devDependencies": {
-    "browser-sync": "^2.24.4",
+    "browser-sync": "^2.24.7",
     "browserify": "^14.3.0",
     "cached-path-relative": "^1.0.2",
     "del": "^2.2.2",


### PR DESCRIPTION
This changes `package.json` to require a newer version of `browser-sync`
It also adds a requirement on versions of
* `cached-path-relative` which is depended on by `browser-sync` but which doesn't require the fixed version
* `node-sass` which is depended on by `gulp-sass` but which doesn't yet require the fixed version

I'm unsure what impact if any these newer versions of packages will have on the product so @hidde should review this.