### PR TITLE
Propose https:// scheme for sso production config

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -4,7 +4,7 @@
   "LDAP_connection_name": "Mozilla-LDAP-Dev",
   "person_api_domain": "https://person-api.sso.allizom.org/v1/connection/",
   "logout_url": "https://auth-dev.mozilla.auth0.com/v2/logout?returnTo=https://sso.allizom.org/signout.html",
-  "sso_dashboard_url": "http://sso.allizom.org",
+  "sso_dashboard_url": "https://sso.allizom.org",
   "GTM_ID": "GTM-T2N2BRW",
   "client_ID": "CIynn5wTPyYZQcA1FJx1Io9z4t7QWDaE",
   "features": {

--- a/config/production.json
+++ b/config/production.json
@@ -4,7 +4,7 @@
   "LDAP_connection_name": "Mozilla-LDAP",
   "person_api_domain": "https://person-api.sso.mozilla.com/v1/connection/",
   "logout_url": "https://auth.mozilla.auth0.com/v2/logout?returnTo=https://sso.mozilla.com/signout.html",
-  "sso_dashboard_url": "http://sso.mozilla.com",
+  "sso_dashboard_url": "https://sso.mozilla.com",
   "GTM_ID": "GTM-T2N2BRW",
   "features": {
     "autologin": "true",


### PR DESCRIPTION
While testing the SSO dashboard I noticed that it's using an http:// scheme for the sso config.  I believe this has a downstream affect on source references that I believe this may fix.  FWIW, I have very little context on this app, and this proposed change should be thoroughly verified before applying it.

Here's an example of the downstream links that I believe are generated by this config and displayed in HTTP responses:

```
<li><a href="http://sso.mozilla.com" class="button button-full-width button-secondary">Back to Dashboard</a></li>
<li><a href="http://sso.mozilla.com/logout" class="button button-full-width button-secondary">Log out of Mozilla</a></li>
```
