### PR TITLE
Ensure all images have alt attributes

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -67,7 +67,7 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
           <legend class="rp-name"><span class="visually-hidden">Log in to </span><span id="rp-name-placeholder" class="rp-name__text"></span></legend>
           <div id="loading" class="loading" data-screen hidden>
             <p class="visually-hidden">Loading…</p>
-            <img src="{{{ cdn }}}/images/loading.svg" class="loading__spinner" />
+            <img src="{{{ cdn }}}/images/loading.svg" class="loading__spinner" alt="" />
             <p role="alert" id="loading__status" class="loading__status"></p>
           </div>
           <div id="initial" data-screen hidden>
@@ -80,26 +80,26 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             <ul class="login-options list list--plain">
               <li data-optional-login-method="firefoxaccounts">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-firefoxaccounts">
-                  <img  class="icon" src="{{{ cdn }}}/images/firefox.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/firefox.svg" alt="">
                   <span>Log in with Firefox</span>
                 </button>
               </li>
               <li data-optional-login-method="github">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-github">
-                  <img class="icon" src="{{{ cdn }}}/images/github.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/github.svg" alt="">
                   <span>Log in with GitHub</span>
                 </button>
               </li>
               <li data-optional-login-method="google-oauth2">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-google">
-                  <img  class="icon" src="{{{ cdn }}}/images/google.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/google.svg" alt="">
                   <span>Log in with Google</span>
                 </button>
             </ul>
             <div data-decorator="hide-autologin-setting-conditionally">
               <hr>
               <div class="setting">
-                <a href="#what-is-autologin" class="link-to-tooltip" data-decorator="tooltip"><span class="visually-hidden">What is Auto-login?</span> <img class="icon" src="{{{ cdn }}}/images/info.svg"></a>
+                <a href="#what-is-autologin" class="link-to-tooltip" data-decorator="tooltip"><span class="visually-hidden">What is Auto-login?</span> <img class="icon" src="{{{ cdn }}}/images/info.svg" alt=""></a>
                 <input type="checkbox" id="use-autologin" data-decorator="set-autologin-preference" checked>
                 <label for="use-autologin"><span class="setting__toggle"></span> <span class="setting__enabled-text">Auto-login is enabled</span><span class="setting__disabled-text">Auto-login is disabled</span></label>
                 <div id="what-is-autologin" class="tooltip">
@@ -118,26 +118,26 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             <ul class="login-options list list--plain">
               <li data-optional-login-method="firefoxaccounts">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-firefoxaccounts">
-                  <img  class="icon" src="{{{ cdn }}}/images/firefox.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/firefox.svg" alt="">
                   <span>Continue with Firefox</span>
                 </button>
               </li>
               <li data-optional-login-method="github">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-github">
-                  <img class="icon" src="{{{ cdn }}}/images/github.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/github.svg" alt="">
                   <span>Continue with GitHub</span>
                 </button>
               </li>
               <li data-optional-login-method="google-oauth2">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-google">
-                  <img  class="icon" src="{{{ cdn }}}/images/google.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/google.svg" alt="">
                   <span>Continue with Google</span>
                 </button>
             </ul>
             <div data-decorator="hide-autologin-setting-conditionally">
               <hr>
               <div class="setting">
-                <a href="#what-is-autologin-2" class="link-to-tooltip" data-decorator="tooltip"><span class="visually-hidden">What is Auto-login?</span> <img class="icon" src="{{{ cdn }}}/images/info.svg"></a>
+                <a href="#what-is-autologin-2" class="link-to-tooltip" data-decorator="tooltip"><span class="visually-hidden">What is Auto-login?</span> <img class="icon" src="{{{ cdn }}}/images/info.svg" alt=""></a>
                 <input type="checkbox" id="use-autologin-2" data-decorator="set-autologin-preference" checked>
                 <label for="use-autologin-2"><span class="setting__toggle"></span> <span class="setting__enabled-text">Auto-login is enabled</span><span class="setting__disabled-text">Auto-login is disabled</span></label>
                 <div id="what-is-autologin-2" class="tooltip">
@@ -166,19 +166,19 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             <ul class="login-options list list--plain">
               <li data-optional-login-method="firefoxaccounts">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-firefoxaccounts">
-                  <img  class="icon" src="{{{ cdn }}}/images/firefox.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/firefox.svg" alt="">
                   <span>Continue with Firefox</span>
                 </button>
               </li>
               <li data-optional-login-method="github">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-github">
-                  <img class="icon" src="{{{ cdn }}}/images/github.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/github.svg" alt="">
                   <span>Continue with GitHub</span>
                 </button>
               </li>
               <li data-optional-login-method="google-oauth2">
                 <button class="button button--full-width button--social button--secondary" type="button" data-handler="authorise-google">
-                  <img class="icon" src="{{{ cdn }}}/images/google.svg">
+                  <img class="icon" src="{{{ cdn }}}/images/google.svg" alt="">
                   <span>Continue with Google</span>
                 </button>
             </ul>
@@ -186,13 +186,13 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to start over with a different account?</button>
           </div>
           <div id="passwordless-success" data-screen hidden>
-            <h2 class="card__heading card__heading--success"><img src="{{{ cdn }}}/images/envelope.svg" class="card__heading-icon" /> <span>Success</span></h2>
+            <h2 class="card__heading card__heading--success"><img src="{{{ cdn }}}/images/envelope.svg" class="card__heading-icon" alt="" /> <span>Success</span></h2>
             <p>Email sent to <span id="passwordless-success-email-address"></span>, go to your inbox to continue. Your login link will expire in 15 minutes.</p>
             <hr>
             <button id="back" type="button" class="button button--text-only card__back  button--unpadded" data-handler="go-to-initial-page">Need to send that to a different email?</button>
           </div>
           <div id="error-password" data-screen hidden>
-            <h2 class="card__heading card__heading--error" id="error-message-ldap"><img src="{{{ cdn }}}/images/circled-x.svg" class="card__heading-icon" /> <span>Error</span></h2>
+            <h2 class="card__heading card__heading--error" id="error-message-ldap"><img src="{{{ cdn }}}/images/circled-x.svg" class="card__heading-icon" alt="" /> <span>Error</span></h2>
             <p>Please attempt again or contact the Help Desk for assistance.</p>
             <div class="form__input">
               <input type="password" id="field-password-try-2" autocomplete="current-password" name="password" data-decorator="submit-with-enter watch-contents" data-continue-with="authorise-ldap-credentials"  />
@@ -203,20 +203,20 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
             <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to start over with a different account?</button>
           </div>
           <div id="error-passwordless" data-screen hidden>
-            <h2 class="card__heading card__heading--error" id="error-message-passwordless"><img src="{{{ cdn }}}/images/circled-x.svg" class="card__heading-icon" /> <span>Error</span></h2>
+            <h2 class="card__heading card__heading--error" id="error-message-passwordless"><img src="{{{ cdn }}}/images/circled-x.svg" class="card__heading-icon" alt="" /> <span>Error</span></h2>
             <p>We cannot send an email to this address</p>
             <button type="button" class="button button--text-only card__back  button--unpadded" data-handler="go-to-initial-page">Try again</button>
             <hr>
             <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to start over with a different account?</button>
           </div>
           <div id="ldap-not-available" data-screen hidden>
-            <h2 class="card__heading card__heading--error"><img src="{{{ cdn }}}/images/circled-x.svg" class="card__heading-icon" /> <span>Error</span></h2>
+            <h2 class="card__heading card__heading--error"><img src="{{{ cdn }}}/images/circled-x.svg" class="card__heading-icon" alt="" /> <span>Error</span></h2>
             <p>Unfortunately, this website does not offer login with Mozilla LDAP.</p>
             <hr>
             <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to start over with a different account?</button>
           </div>
           <div id="ldap-required" data-screen hidden>
-            <h2 class="card__heading card__heading--error"><img src="{{{ cdn }}}/images/circled-x.svg" class="card__heading-icon" /> <span>Error</span></h2>
+            <h2 class="card__heading card__heading--error"><img src="{{{ cdn }}}/images/circled-x.svg" class="card__heading-icon" alt="/> <span>Error</span></h2>
             <p>Unfortunately, you can only login to this website using Mozilla LDAP.</p>
             <hr>
             <button type="button" class="button button--text-only card__back button--unpadded" data-handler="go-to-initial-page">Need to start over with a different account?</button>


### PR DESCRIPTION
This is an accessibility improvement.

Problem in current code: some images don't have alt attributes. For screenreaders, that means that the URL of the image is read out to users, which would be a bit annoying.

These images are all decoration, so their `alt` attributes should be empty; in screenreader terms that means they'll get ignored.