### PR TITLE
increase padding on help links for mobiles

### DIFF
--- a/src/scss/components/_legal-links.scss
+++ b/src/scss/components/_legal-links.scss
@@ -23,7 +23,7 @@
   a {
     text-decoration: none;
     color: $black;
-    padding: .5em 1em;
+    padding: 2em 1em;
 
     &:hover {
       color: $blue;


### PR DESCRIPTION
before:

![Screenshot from 2019-11-01 10-26-33](https://user-images.githubusercontent.com/755354/68018874-22c0db80-fc92-11e9-95d1-d1a1da72847d.png)

after:

![Screenshot from 2019-11-01 10-25-14](https://user-images.githubusercontent.com/755354/68018878-26546280-fc92-11e9-9825-0b08f8769ee5.png)
