### PR TITLE
fix(mozilla-account): Use remove instead of hide

### DIFF
--- a/src/js/decorators/show-mozilla-accounts.js
+++ b/src/js/decorators/show-mozilla-accounts.js
@@ -6,6 +6,6 @@ module.exports = function showMozillaAccounts( accounts ) {
 
   if ( mozilla_accounts_banner_post  === 'true') {
     ui.show( accounts );
-    ui.hide( firefox_accounts );
+    firefox_accounts.remove();
   }
 };


### PR DESCRIPTION
This seems to remove the element between different states as well. 

![Screenshot 2023-10-05 at 12-52-27 Mozilla Login](https://github.com/mozilla-iam/auth0-custom-lock/assets/1072933/d919e8ba-e827-4883-9f09-ce10bdad7a18)
