### PR TITLE
Remove broken image link

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -89,7 +89,7 @@ on GitHub: https://github.com/mozilla-iam/auth0-custom-lock
                 </div>
                 <div class="flex-initial max-w-md">
                     <p class="text-l font-bold">
-                        <a href="{{{ sso_dashboard_url }}}/images/mozilla-new-login-prompt.png">This login page will have a new look after June 15, 2025.</a>
+                        This login page will have a new look after June 15, 2025.
                     </p>
                     <p class="text-s">
                         You’ll still sign in with the same username and password, and there are no other changes to the products that you use.


### PR DESCRIPTION
This is a hotfix that has been deployed to both dev and prod.  It removes the broken link in the banner.